### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "normalize-scss": "^7.0.1",
-    "npm": "^5.10.0",
     "object-fit-images": "^3.2.3",
     "parallax-js": "^3.1.0",
     "particles.js": "^2.0.0",


### PR DESCRIPTION

Hello Danil44!

It seems like you have npm as one of your (dev-) dependency in swiss_energy.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
